### PR TITLE
Add links to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,8 @@ Suggests:
     testthat
 LazyData: true
 VignetteBuilder: knitr
+URL: https://tysonbarrett.com/furniture/, https://github.com/TysonStanley/furniture
+BugReports: https://github.com/TysonStanley/furniture/issues
 Encoding: UTF-8
 License: GPL-3
 RoxygenNote: 7.2.3


### PR DESCRIPTION
You may also consider adding the site to the About section of the repo homepage (top-right corner)
![image](https://github.com/TysonStanley/furniture/assets/52606734/b7d2eee7-6073-4729-b924-eccd90638943)
